### PR TITLE
Use canSee to determine whether to show a field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kirschbaum-development/nova-inline-relationship",
+    "name": "arrow-web-sol/nova-inline-relationship",
     "description": "A Laravel Nova field for displaying relationship properties inline.",
     "keywords": [
         "laravel",


### PR DESCRIPTION
At present, a field will be shown even if the user fails the canSee criteria of the field.

This checks to see if we have any criteria set (as the seeCallback closure) and if so, it'll remove any fields that don't pass the criteria.