### PR TITLE
Check if value is a instance of Collection

### DIFF
--- a/src/NovaInlineRelationship.php
+++ b/src/NovaInlineRelationship.php
@@ -82,7 +82,7 @@ class NovaInlineRelationship extends Field
         $this->withMeta([
             'defaults' => $this->getDefaultsFromProperties($properties)->all(),
             'settings' => $properties->all(),
-            'models' => $this->value ? $this->value->pluck('id')->all() : [],
+            'models' => $this->value instanceof Collection ? $this->value->pluck('id')->all() : [],
             'modelKey' => Str::plural(Str::kebab(class_basename(optional($this->value)->first() ?? $resource->{$attribute}()->getRelated()->newInstance()))),
             'singularLabel' => Str::title(Str::singular($this->name)),
             'pluralLabel' => Str::title(Str::plural($this->name)),


### PR DESCRIPTION
Not sure if this is intended, but if `$this->value` is a `Model` instance, the `pluck` method will return all ids from the database, which is really slow here (>1M records).