### PR TITLE
Changes singularLabel to stop forcibly converting plural labels

### DIFF
--- a/src/NovaInlineRelationship.php
+++ b/src/NovaInlineRelationship.php
@@ -308,9 +308,7 @@ class NovaInlineRelationship extends Field
         }
 
         $item['meta'] = $class->jsonSerialize();
-        // We are using Singular Label instead of name to display labels as compound name will be used in Vue
-        $item['meta']['singularLabel'] = Str::title(str_replace('_', ' ', $item['label'] ?? $attrib));
-
+        $item['meta']['singularLabel'] = $item['label'] ?? $attrib;
         $item['meta']['placeholder'] = 'Add ' . $item['meta']['singularLabel'];
 
         return $item;

--- a/src/NovaInlineRelationship.php
+++ b/src/NovaInlineRelationship.php
@@ -309,7 +309,7 @@ class NovaInlineRelationship extends Field
 
         $item['meta'] = $class->jsonSerialize();
         // We are using Singular Label instead of name to display labels as compound name will be used in Vue
-        $item['meta']['singularLabel'] = Str::title(Str::singular(str_replace('_', ' ', $item['label'] ?? $attrib)));
+        $item['meta']['singularLabel'] = Str::title(str_replace('_', ' ', $item['label'] ?? $attrib));
 
         $item['meta']['placeholder'] = 'Add ' . $item['meta']['singularLabel'];
 


### PR DESCRIPTION
Fixes: https://github.com/kirschbaum-development/nova-inline-relationship/issues/45

Field Labels are forcibly updated to singular. Updated the behaviour.