### PR TITLE
Use `singularLabel` for field name when editing

### DIFF
--- a/resources/js/components/RelationshipFormItem.vue
+++ b/resources/js/components/RelationshipFormItem.vue
@@ -80,7 +80,7 @@
                                     'attribute': (this.value[attrib].meta.component === "file-field") ?
                                         attrib + '?' + this.id :
                                         this.field.attribute + '_' + this.id + '_' + attrib, // This is needed to enable delete link for file without triggering duplicate id warning
-                                    'name': this.field.attribute + '[' + this.id + '][' + attrib + ']',
+                                    'name': this.value[attrib].meta.singularLabel,
                                     'deletable': this.modelId > 0, // Hide delete button if model Id is not present, i.e. new model
                                     'attrib': attrib
                                 }


### PR DESCRIPTION
Just like the [RelationshipDetailItem](https://github.com/kirschbaum-development/nova-inline-relationship/blob/master/resources/js/components/RelationshipDetailItem.vue#L81) I think the `RelationshipFormItem` should use the singular label for the field name to avoid the following:

![image](https://user-images.githubusercontent.com/947230/74728426-05b11800-5243-11ea-8042-1128e022c9c2.png)

Let me know if you want me to change it to check for `singular` and display the plural name too?
