### PR TITLE
Fix typehint on getRelationshipObserver

### DIFF
--- a/src/Observers/NovaInlineRelationshipObserver.php
+++ b/src/Observers/NovaInlineRelationshipObserver.php
@@ -80,7 +80,7 @@ class NovaInlineRelationshipObserver
      *
      * @return RelationshipObservable
      */
-    public function getRelationshipObserver(Model $model, $relationship): RelationshipObservable
+    public function getRelationshipObserver(Model $model, $relationship): ?RelationshipObservable
     {
         $className = NovaInlineRelationshipHelper::getObserver($model->{$relationship}());
 


### PR DESCRIPTION
Fixing the typehint on `getRelationshipObserver` to allow for `null` returns

Fixes #69 